### PR TITLE
Flat Lines Block and csdt.rpi.edu References

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 CSnap: Bringing Culture and Social Justice to Programming
 =========================================================
 
-http://csdt.rpi.edu
+http://csdt.org
 
 License
 -------

--- a/gui.js
+++ b/gui.js
@@ -338,8 +338,8 @@ IDE_Morph.prototype.openIn = function (world) {
     // dynamic notifications from non-source text files
     // has some issues, commented out for now
     /*
-    this.cloudMsg = getURL('http://csdt.rpi.edu/cloudmsg.txt');
-    motd = getURL('http://csdt.rpi.edu/motd.txt');
+    this.cloudMsg = getURL('http://csdt.org/cloudmsg.txt');
+    motd = getURL('http://csdt.org/motd.txt');
     if (motd) {
         this.inform('CSnap', motd);
     }
@@ -2252,7 +2252,7 @@ IDE_Morph.prototype.snapMenu = function () {
     menu.addItem(
         'CSnap website',
         function () {
-            window.open('http://csdt.rpi.edu/', 'CSnapWebsite');
+            window.open('http://csdt.org/', 'CSnapWebsite');
         }
     );
 /* XXX: If we really need this in the future, we should link to the CSnap GitHub page.
@@ -2788,7 +2788,7 @@ IDE_Morph.prototype.projectMenu = function () {
         function () {
             myself.droppedText(
                 myself.getURL(
-                    'https://csdt.rpi.edu/csnapsource/tools.xml'
+                    'https://csdt.org/csnapsource/tools.xml'
                 ),
                 'tools'
             );
@@ -2800,11 +2800,11 @@ IDE_Morph.prototype.projectMenu = function () {
         function () {
             // read a list of libraries from an external file,
             var libMenu = new MenuMorph(this, 'Import library'),
-                libUrl = 'https://csdt.rpi.edu/csnapsource/libraries/' +
+                libUrl = 'https://csdt.org/csnapsource/libraries/' +
                     'LIBRARIES';
 
             function loadLib(name) {
-                var url = 'https://csdt.rpi.edu/csnapsource/libraries/'
+                var url = 'https://csdt.org/csnapsource/libraries/'
                         + name
                         + '.xml';
                 myself.droppedText(myself.getURL(url), name);
@@ -4528,7 +4528,7 @@ IDE_Morph.prototype.cloudError = function () {
         // and notify the user about it,
         // if none is found, show an error dialog box
         var response = responseText,
-            explanation = getURL('http://csdt.rpi.edu/cloudmsg.txt');
+            explanation = getURL('http://csdt.org/cloudmsg.txt');
         if (myself.shield) {
             myself.shield.destroy();
             myself.shield = null;

--- a/objects.js
+++ b/objects.js
@@ -695,6 +695,11 @@ SpriteMorph.prototype.initBlocks = function () {
             category: 'pen',
             spec: 'fix borders'
         },
+		flatLineEnds: {
+            type: 'command',
+            category: 'pen',
+            spec: 'flat line end? %b'
+        },
         // 3D shapes
         renderSphere: {
             type: 'command',
@@ -1999,6 +2004,7 @@ SpriteMorph.prototype.blockTemplates = function (category) {
         blocks.push('-');
         blocks.push(block('doStamp'));
         blocks.push(block('smoothBorders'));
+        blocks.push(block('flatLineEnds'));
 
         if (this.costume && this.costume.is3D) {
             blocks.push(block('clear'));
@@ -6476,7 +6482,7 @@ function Costume(canvas, name, rotationCenter, url, is3D, is3dSwitchable) {
     // newly added for 3D
     this.url = url;
     this.is3D = is3D;
-    this.is3dSwitchable = is3dSwitchable
+    this.is3dSwitchable = is3dSwitchable;
     this.geometry = null;
     this.map = null;
 }
@@ -8042,4 +8048,10 @@ function round10(val,exp)
 {
 	var pow = Math.pow(10,exp);
 	return Math.round(val/pow)*pow;
+}
+
+
+//CSDT Blocks
+SpriteMorph.prototype.flatLineEnds = function(bool){
+    SpriteMorph.prototype.useFlatLineEnds = bool;
 }

--- a/objects.js
+++ b/objects.js
@@ -1030,7 +1030,7 @@ SpriteMorph.prototype.initBlocks = function () {
             type: 'reporter',
             category: 'sensing',
             spec: 'http:// %s',
-            defaults: ['csdt.rpi.edu']
+            defaults: ['csdt.org']
         },
         reportIsFastTracking: {
             type: 'predicate',
@@ -8055,3 +8055,4 @@ function round10(val,exp)
 SpriteMorph.prototype.flatLineEnds = function(bool){
     SpriteMorph.prototype.useFlatLineEnds = bool;
 }
+

--- a/store.js
+++ b/store.js
@@ -252,7 +252,7 @@ SnapSerializer.uber = XML_Serializer.prototype;
 
 // SnapSerializer constants:
 
-SnapSerializer.prototype.app = 'CSnap 1.0, https://csdt.rpi.edu';
+SnapSerializer.prototype.app = 'CSnap 1.0, https://csdt.org';
 
 SnapSerializer.prototype.thumbnailSize = new Point(160, 120);
 

--- a/ypr.js
+++ b/ypr.js
@@ -1407,7 +1407,7 @@ var sb = (function (sb) {
 			});
 			xml = n('project', {
 				name: projectName,
-				app: 'CSnap 1.0, http://csdt.rpi.edu; serialized by yprxml, http://dl.dropbox.com/u/10715865/Web/snap/app/yprxml.html',
+				app: 'CSnap 1.0, http://csdt.org; serialized by yprxml, http://dl.dropbox.com/u/10715865/Web/snap/app/yprxml.html',
 				version: '1'
 			}, [
 				n('notes', {}, [t(project.info.get('comment') || '')]),


### PR DESCRIPTION
Added a block that takes advantage of the flat line option, replaces references to csdt.rpi.edu with csdt.org